### PR TITLE
ENH/WIP: add support for tree layout

### DIFF
--- a/qtpynodeeditor/connection.py
+++ b/qtpynodeeditor/connection.py
@@ -49,7 +49,7 @@ class Connection(QObject, Serializable):
         if in_port is not None:
             if in_port.connections:
                 conn, = in_port.connections
-                existing_in, existing_out = conn.ports
+                existing_out, existing_in = conn.ports
                 if existing_in == in_port and existing_out == out_port:
                     raise exceptions.PortsAlreadyConnectedError(
                         'Specified ports already connected')
@@ -98,7 +98,7 @@ class Connection(QObject, Serializable):
         -------
         value : dict
         """
-        in_port, out_port = self.ports
+        out_port, in_port = self.ports
         if not in_port and not out_port:
             return {}
 
@@ -248,12 +248,12 @@ class Connection(QObject, Serializable):
     @property
     def nodes(self):
         # TODO namedtuple; TODO order
-        return (self.get_node(PortType.input), self.get_node(PortType.output))
+        return (self.get_node(PortType.output), self.get_node(PortType.input))
 
     @property
     def ports(self):
         # TODO namedtuple; TODO order
-        return (self._ports[PortType.input], self._ports[PortType.output])
+        return (self._ports[PortType.output], self._ports[PortType.input])
 
     def get_port_index(self, port_type: PortType) -> int:
         """
@@ -347,7 +347,7 @@ class Connection(QObject, Serializable):
         ----------
         node_data : NodeData
         """
-        in_port, out_port = self.ports
+        out_port, in_port = self.ports
         if not in_port:
             return
 

--- a/qtpynodeeditor/examples/calculator.py
+++ b/qtpynodeeditor/examples/calculator.py
@@ -270,7 +270,7 @@ class NumberSourceDataModel(NodeDataModel):
         try:
             number = float(self._line_edit.text())
         except ValueError:
-            self._data_invalidated.emit(0)
+            self.data_invalidated.emit(0)
         else:
             self._number = DecimalData(number)
             self.data_updated.emit(0)

--- a/qtpynodeeditor/flow_scene.py
+++ b/qtpynodeeditor/flow_scene.py
@@ -213,7 +213,7 @@ class FlowSceneModel:
         ----------
         conn : Connection
         """
-        input_node, output_node = conn.nodes
+        output_node, input_node = conn.nodes
         assert input_node is not None
         assert output_node is not None
         output_node.model.output_connection_created(conn)
@@ -227,7 +227,7 @@ class FlowSceneModel:
         ----------
         conn : Connection
         """
-        input_node, output_node = conn.nodes
+        output_node, input_node = conn.nodes
         assert input_node is not None
         assert output_node is not None
         output_node.model.output_connection_deleted(conn)
@@ -537,7 +537,7 @@ class FlowScene(FlowSceneModel, QGraphicsScene):
         self._connections.append(connection)
 
         if port_a and port_b:
-            in_port, out_port = connection.ports
+            out_port, in_port = connection.ports
             out_port.node.on_data_updated(out_port)
             self.connection_created.emit(connection)
 

--- a/qtpynodeeditor/flow_scene.py
+++ b/qtpynodeeditor/flow_scene.py
@@ -666,14 +666,31 @@ class FlowScene(FlowSceneModel, QGraphicsScene):
             for name in ('bipartite', 'circular', 'kamada_kawai', 'random',
                          'shell', 'spring', 'spectral')
         }
+        layouts["pygraphviz"] = networkx.nx_agraph.pygraphviz_layout
 
         try:
             layout_func = layouts[layout]
         except KeyError:
             raise ValueError(f'Unknown layout type {layout}') from None
 
-        layout = layout_func(dig, **kwargs)
-        for node, pos in layout.items():
+        # pygraphviz layouts seem to take node labels into account for spacing
+        # (in our case this is the the long repr)
+        if layout == "pygraphviz":
+            int_to_node = {i: node for i, node in enumerate(dig.nodes)}
+            node_to_int = {node: i for i, node in int_to_node.items()}
+            dig = networkx.relabel_nodes(dig, node_to_int)
+
+        layout_data = layout_func(dig, **kwargs)
+        # some layouts are not unit vector scaled
+        layout_data = networkx.rescale_layout_dict(layout_data)
+
+        if layout == "pygraphviz":
+            # undo int mapping, flip y orientation
+            dig = networkx.relabel_nodes(dig, int_to_node)
+            layout_data = {int_to_node[node_label]: (pos_x, -pos_y)
+                           for node_label, (pos_x, pos_y) in layout_data.items()}
+
+        for node, pos in layout_data.items():
             pos_x, pos_y = pos
             node.position = (pos_x * scale, pos_y * scale)
 

--- a/qtpynodeeditor/node_connection_interaction.py
+++ b/qtpynodeeditor/node_connection_interaction.py
@@ -170,7 +170,7 @@ class NodeConnectionInteraction:
         self._node.graphics_object.move_connections()
 
         # 5) Poke model to intiate data transfer
-        _, out_port = self._connection.ports
+        out_port, in_port = self._connection.ports
         if out_port:
             out_port.node.on_data_updated(out_port)
 

--- a/qtpynodeeditor/node_geometry.py
+++ b/qtpynodeeditor/node_geometry.py
@@ -240,7 +240,7 @@ class NodeGeometry:
         port_type: PortType,
         index: int
     ) -> typing.Tuple[float, float]:
-        
+
         step = self._entry_height + self._spacing
         total_height = float(self.caption_height) + step * index
         # TODO_UPSTREAM: why?
@@ -259,7 +259,7 @@ class NodeGeometry:
         port_type: PortType,
         index: int
     ) -> typing.Tuple[float, float]:
-        
+
         step = self._entry_height + self._spacing
         # TODO: see if we can set up centered nodes
         total_width = step * index

--- a/qtpynodeeditor/style.py
+++ b/qtpynodeeditor/style.py
@@ -1,7 +1,7 @@
-from enum import StrEnum, auto
 import json
 import logging
 import random
+from enum import StrEnum, auto
 
 from qtpy.QtGui import QColor
 
@@ -255,7 +255,7 @@ class NodeStyle(Style):
         self.connection_point_diameter = float(
             style['ConnectionPointDiameter'])
         self.opacity = float(style['Opacity'])
-        self.layout_direction = LayoutDirection[style["LayoutDirection"]]
+        self.layout_direction = LayoutDirection[style.get("LayoutDirection", "HORIZONTAL")]
 
 
 class StyleCollection:

--- a/qtpynodeeditor/style.py
+++ b/qtpynodeeditor/style.py
@@ -1,3 +1,4 @@
+from enum import StrEnum, auto
 import json
 import logging
 import random
@@ -19,6 +20,19 @@ def _get_qcolor(style_dict, key):
     logger.debug('Loaded color %s = %s -> %d %d %d %d', key, name_or_list,
                  *color.getRgb())
     return color
+
+
+class LayoutDirection(StrEnum):
+    HORIZONTAL = auto()
+    VERTICAL = auto()
+
+    @classmethod
+    def _missing_(cls, value: str):
+        value = value.lower()
+        for member in cls:
+            if member.value == value:
+                return member
+        return None
 
 
 class Style:
@@ -48,7 +62,9 @@ class Style:
 
             "ConnectionPointDiameter": 8.0,
 
-            "Opacity": 0.8
+            "Opacity": 0.8,
+
+            "LayoutDirection": "HORIZONTAL"
         },
         "ConnectionStyle": {
             "ConstructionColor": "gray",
@@ -200,6 +216,8 @@ class NodeStyle(Style):
         self.connection_point_diameter = 5.0
         self.opacity = 1.0
 
+        self.layout_direction = LayoutDirection.HORIZONTAL
+
         super().__init__(json_style=json_style)
 
     def load_from_json(self, json_style: str):
@@ -237,6 +255,7 @@ class NodeStyle(Style):
         self.connection_point_diameter = float(
             style['ConnectionPointDiameter'])
         self.opacity = float(style['Opacity'])
+        self.layout_direction = LayoutDirection[style["LayoutDirection"]]
 
 
 class StyleCollection:


### PR DESCRIPTION
## Description
A big-ish lift to support using this node editor for behavior tree representations

* Add a `LayoutDirection` option to the general style config, and re-position the nodes based on that
* Add support for a pygraphviz layout, involving a bit of hacking around differences between the various networkx layout functions
* Re-orders edge direction to make more sense for Directed graphs (source, sink)

* Fix some small-ish bugs
  * some typo-d method calls in the calculator example (that don't frequently get called)


## Motivation and Context
BEAMS wants some graphical interfaces, and we want to make qtpynodeeditor work for that.  Maybe in the future we upstream this.

## How Has This Been Tested?
Interactively

## Where Has This Been Documented?
This PR